### PR TITLE
Refactor core functions and view code to support export via HTTP request or by direct function call

### DIFF
--- a/openedx_export_plugins/constants.py
+++ b/openedx_export_plugins/constants.py
@@ -1,0 +1,5 @@
+"""
+Constants for openedx_export_plugins Django app.
+"""
+
+EXPORT_FILENAME_FORMAT_MULTIPLE = "all_courses_as_{}_{}.tar{}"

--- a/openedx_export_plugins/constants.py
+++ b/openedx_export_plugins/constants.py
@@ -2,4 +2,4 @@
 Constants for openedx_export_plugins Django app.
 """
 
-EXPORT_FILENAME_FORMAT_MULTIPLE = "all_courses_as_{}_{}.tar{}"
+EXPORT_FILENAME_FORMAT_MULTIPLE = "all_courses_as_{}_{}.tar"

--- a/openedx_export_plugins/core.py
+++ b/openedx_export_plugins/core.py
@@ -5,9 +5,9 @@ Core export functionality.
 import datetime
 import io
 import os
-from tempfile import mkdtemp
 import shutil
 import tarfile
+from tempfile import mkdtemp
 
 from django.core.exceptions import PermissionDenied
 
@@ -48,7 +48,7 @@ def export_courses_multiple(user, plugin_class, course_keys, outfilename, stream
                     continue
             try:
                 if stream:
-                    for tar_bytes in course_tar_bytes(user, plugin_class, course_key, out_tar):
+                    for tar_bytes in _course_tar_bytes(user, plugin_class, course_key, out_tar):
                         yield tar_bytes
                 else:
                     output_filepath, out_fn = _do_course_export(plugin_class, course_key)
@@ -68,7 +68,7 @@ def _get_tar_end_padding_bytes():
     return pad_data.getvalue()
 
 
-def course_tar_bytes(user, plugin_class, course_key, out_tar):
+def _course_tar_bytes(user, plugin_class, course_key, out_tar):
     """
     Generate tarball data from multiple course exports
     """

--- a/openedx_export_plugins/core.py
+++ b/openedx_export_plugins/core.py
@@ -1,0 +1,114 @@
+"""
+Core export functionality.
+"""
+
+import datetime
+import io
+import os
+from tempfile import mkdtemp
+import shutil
+import tarfile
+
+from django.core.exceptions import PermissionDenied
+
+from xmodule.contentstore.django import contentstore
+from xmodule.exceptions import SerializationError
+from xmodule.modulestore.django import modulestore
+
+from student.auth import has_course_author_access
+
+
+def export_course_single(user, plugin_class, course_key):
+    """
+    Generate a single export file and return a path to it and its name.
+    """
+    if not has_course_author_access(user, course_key):
+        raise PermissionDenied()
+
+    try:
+        (outfilepath, out_fn) = _do_course_export(user, plugin_class, course_key)
+    except SerializationError:
+        raise  # TODO: maybe do something better here
+
+    # return a single export file in the response
+    return (outfilepath, out_fn)
+
+def export_courses_multiple(user, plugin_class, course_keys, outfilename, stream=False):
+    """
+    Build a tar file from multi-course export and either yield its bytes to stream 
+    or return a finished gzipped tar file.
+    """
+    tarf = os.path.join(mkdtemp(), outfilename)
+    with tarfile.open(tarf, "w:") as out_tar:
+        for tar_bytes in courses_tar_bytes(user, plugin_class, course_keys, out_tar):
+            if stream:
+                yield tar_bytes            
+            else:
+                out_tar.write(tar_bytes)
+        if not stream:
+            yield out_tar
+
+
+def courses_tar_bytes(user, plugin_class, course_keys, out_tar):
+    """
+    Generate tarball data from multiple course exports
+    """
+
+    def _get_tar_record_bytes(tarinfo, src_file_path):
+        tar_header = tarinfo.tobuf(out_tar.format, out_tar.encoding, out_tar.errors)
+
+        # replicating behavior of TarFile.add
+        tar_data = io.BytesIO()
+        with open(src_file_path, "r") as src:
+            shutil.copyfileobj(src, tar_data, length=tarinfo.size)
+            blocks, remainder = divmod(tarinfo.size, tarfile.BLOCKSIZE)
+            if remainder > 0:
+                tar_data.write(tarfile.NUL * (tarfile.BLOCKSIZE - remainder))
+
+        return (tar_header, tar_data.getvalue())
+
+    def _get_tar_end_padding_bytes():
+        """tar files are finished with two blocks of zeros."""
+        pad_data = io.BytesIO()
+        pad_data.write(tarfile.NUL * (tarfile.BLOCKSIZE * 2))
+        return pad_data.getvalue()
+
+    for course_key in course_keys:
+        if not has_course_author_access(user, course_key):
+            logger.warn('User {} has no access to export {}'.format(user, course_key))
+            continue
+        try:
+            (outfilepath, out_fn) = _do_course_export(user, plugin_class, course_key)
+
+            # yield tar format data bit by bit,...
+            tarinfo = out_tar.gettarinfo(name=outfilepath, arcname=out_fn)
+            (tar_hd, tar_data) = _get_tar_record_bytes(tarinfo, outfilepath)
+            yield tar_hd
+            yield tar_data
+
+        except SerializationError as e:
+            logger.warn('Could not export {} due to core OLX export error {}. Skipping.'.format(course_key, e.message))
+            continue
+
+    # ...now add the padding to mark the end of the tarfile
+    yield _get_tar_end_padding_bytes()
+
+
+def _do_course_export(user, plugin_class, course_key):
+    """
+    Run the actual export transformation.
+    """
+    root_dir = mkdtemp()
+    course_key_normalized = str(course_key).replace('/', '+')
+    target_dir = os.path.normpath(course_key_normalized)
+    exporter = plugin_class(modulestore(), contentstore(), course_key, root_dir, target_dir)
+    fn_ext = exporter.filename_extension
+    exporter.export()
+
+    output_filepath = os.path.join(root_dir, target_dir, "output.{}".format(fn_ext))
+    out_fn = "{}_{}.{}".format(
+        course_key_normalized,
+        datetime.datetime.now().strftime('%Y-%m-%d'),
+        fn_ext
+    )
+    return (output_filepath, out_fn)

--- a/openedx_export_plugins/exceptions.py
+++ b/openedx_export_plugins/exceptions.py
@@ -1,0 +1,9 @@
+"""
+Custom exceptions for openedx_export_plugins Django app.
+"""
+
+
+class ExportPluginsCourseExportError(Exception):
+    """
+    Exception exporting a course.
+    """

--- a/openedx_export_plugins/exporters/markdown.py
+++ b/openedx_export_plugins/exporters/markdown.py
@@ -23,9 +23,8 @@ class MarkdownCourseExportManager(base.PluggableCourseExportManager):
     with open(os.path.join(os.path.dirname(__file__), 'xsl', 'md_single_doc.xsl'), 'r') as xslf:
         DEFAULT_XSL_STYLESHEET = xslf.read()
 
-    @property
-    def filename_extension(self):
-        return "md"
+    http_content_type = "text/markdown"
+    filename_extension = "md"
 
     def post_process(self, root, export_fs):
         """

--- a/openedx_export_plugins/models.py
+++ b/openedx_export_plugins/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Database models for openedx_export_plugins.
 """

--- a/openedx_export_plugins/views.py
+++ b/openedx_export_plugins/views.py
@@ -65,9 +65,11 @@ def plugin_export_handler(request, plugin_name, course_key_string=None):
     else:
         # if exporting all files, stream the response back to avoid proxy timeout at front-end webserver
         # return a tarball of all export files in the response
-        outfilename = 'all_courses_as_{}_{}.tar'.format(
+        outfilename = constants.EXPORT_FILENAME_FORMAT_MULTIPLE.format(
             plugin_class.filename_extension,
-            datetime.datetime.now().strftime('%Y-%m-%d'))
+            datetime.datetime.now().strftime('%Y-%m-%d'),
+            ''
+        )
         response = StreamingHttpResponse(
             core.export_courses_multiple(request.user, plugin_class, course_keys, outfilename, stream=True),
             content_type='application/tar'

--- a/openedx_export_plugins/views.py
+++ b/openedx_export_plugins/views.py
@@ -16,11 +16,10 @@ from django.http import HttpResponse, Http404, StreamingHttpResponse
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 
-from xmodule.modulestore.django import modulestore
-
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.lib.api import plugins
 from util.views import ensure_valid_course_key
+from xmodule.modulestore.django import modulestore
 
 from . import constants, core
 from .plugins import CourseExporterPluginManager

--- a/openedx_export_plugins/views.py
+++ b/openedx_export_plugins/views.py
@@ -3,121 +3,30 @@ Views for export plugins.
 """
 
 import datetime
-import io
 import logging
 import os
-from tempfile import mkdtemp
-import shutil
-import tarfile
 
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import PermissionDenied
-from django.core.servers.basehttp import FileWrapper
-from django.http import FileResponse, HttpResponse, Http404, StreamingHttpResponse
+try:
+    # removed in Django 1.9
+    from django.core.servers.basehttp import FileWrapper
+except ImportError:
+    from wsgiref.util import FileWrapper
+from django.http import HttpResponse, Http404, StreamingHttpResponse
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 
-from xmodule.contentstore.django import contentstore
-from xmodule.exceptions import SerializationError
 from xmodule.modulestore.django import modulestore
 
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.lib.api import plugins
-from student.auth import has_course_author_access
 from util.views import ensure_valid_course_key
 
+from . import core
 from .plugins import CourseExporterPluginManager
 
 
 logger = logging.getLogger(__name__)
-
-
-def _export_course_single(user, plugin_class, course_key):
-    """
-    Generate a single export file to return.
-    """
-    if not has_course_author_access(user, course_key):
-            raise PermissionDenied()
-
-    try:
-        (outfilepath, response_fn) = _do_course_export(user, plugin_class, course_key)
-    except SerializationError:
-        raise  # TODO: maybe do something better here
-
-    # return a single export file in the response
-    with open(outfilepath) as outfile:
-        wrapper = FileWrapper(outfile)
-        response = HttpResponse(wrapper, content_type='text/markdown; charset=UTF-8')
-        response['Content-Disposition'] = 'attachment; filename={}'.format(os.path.basename(response_fn.encode('utf-8')))
-        response['Content-Length'] = os.path.getsize(outfile.name)
-        return response
-
-
-def _export_courses_multiple(user, plugin_class, course_keys, tarf):
-    """
-    Generate tarball data from multiple course exports
-    """
-
-    def _get_tar_record_bytes(tarinfo, src_file_path):
-        tar_header = tarinfo.tobuf(response_tar.format, response_tar.encoding, response_tar.errors)
-
-        # replicating behavior of TarFile.add
-        tar_data = io.BytesIO()
-        with open(src_file_path, "r") as src:
-            shutil.copyfileobj(src, tar_data, length=tarinfo.size)
-            blocks, remainder = divmod(tarinfo.size, tarfile.BLOCKSIZE)
-            if remainder > 0:
-                tar_data.write(tarfile.NUL * (tarfile.BLOCKSIZE - remainder))
-
-        return (tar_header, tar_data.getvalue())
-
-    def _get_tar_end_padding_bytes():
-        """tar files are finished with two blocks of zeros."""
-        pad_data = io.BytesIO()
-        pad_data.write(tarfile.NUL * (tarfile.BLOCKSIZE * 2))
-        return pad_data.getvalue()
-
-    response_tar = tarfile.open(tarf, "w:")
-
-    for course_key in course_keys:
-        if not has_course_author_access(user, course_key):
-            logger.warn('User {} has no access to export {}'.format(user, course_key))
-            continue
-        try:
-            (outfilepath, response_fn) = _do_course_export(user, plugin_class, course_key)
-
-            # yield tar format data bit by bit,...
-            tarinfo = response_tar.gettarinfo(name=outfilepath, arcname=response_fn)
-            (tar_hd, tar_data) = _get_tar_record_bytes(tarinfo, outfilepath)
-            yield tar_hd
-            yield tar_data
-
-        except SerializationError as e:
-            logger.warn('Could not export {} due to core OLX export error {}. Skipping.'.format(course_key, e.message))
-            continue
-
-    # ...now add the padding to mark the end of the tarfile
-    yield _get_tar_end_padding_bytes()
-
-
-def _do_course_export(user, plugin_class, course_key):
-    """
-    Run the actual export transformation.
-    """
-    root_dir = mkdtemp()
-    course_key_normalized = str(course_key).replace('/', '+')
-    target_dir = os.path.normpath(course_key_normalized)
-    exporter = plugin_class(modulestore(), contentstore(), course_key, root_dir, target_dir)
-    fn_ext = exporter.filename_extension
-    exporter.export()
-
-    output_filepath = os.path.join(root_dir, target_dir, "output.{}".format(fn_ext))
-    response_fn = "{}_{}.{}".format(
-        course_key_normalized,
-        datetime.datetime.now().strftime('%Y-%m-%d'),
-        fn_ext
-    )
-    return (output_filepath, response_fn)
 
 
 @ensure_csrf_cookie
@@ -132,6 +41,7 @@ def plugin_export_handler(request, plugin_name, course_key_string=None):
     store = modulestore()
     try:
         plugin_class = CourseExporterPluginManager.get_plugin(plugin_name)
+        plugin_ctype = plugin_class.http_content_type
     except plugins.PluginError:
         raise Http404
 
@@ -145,15 +55,22 @@ def plugin_export_handler(request, plugin_name, course_key_string=None):
         course_keys = [course.id for course in courses]
 
     if len(course_keys) == 1:
-        return _export_course_single(request.user, plugin_class, course_keys[0])
+        (outfilepath, outfn) = core.export_course_single(request.user, plugin_class, course_keys[0])
+        with open(outfilepath) as outfile:
+            wrapper = FileWrapper(outfile)
+            response = HttpResponse(wrapper, content_type='{}; charset=UTF-8'.format(plugin_ctype))
+            response['Content-Disposition'] = 'attachment; filename={}'.format(outfn)
+            response['Content-Length'] = os.path.getsize(outfilepath)
+            return response
     else:
-        # TODO: really we should pass this off to Celery and make a view to list and download the
-        # completed file simliar to Instructor dashboard.  This is a shortcut until then.
         # if exporting all files, stream the response back to avoid proxy timeout at front-end webserver
         # return a tarball of all export files in the response
-        exporter = plugin_class(modulestore(), contentstore(), course_keys[0], "/tmp", "")  # just to get extension
-        tarf = os.path.join(mkdtemp(), 'all_courses_as_{}_{}.tar'.format(exporter.filename_extension, datetime.datetime.now().strftime('%Y-%m-%d')))
-        # response = FileResponse(_export_courses_multiple(request.user, plugin_class, course_keys, response_tar), content_type='application/tar')
-        response = StreamingHttpResponse(_export_courses_multiple(request.user, plugin_class, course_keys, tarf), content_type='application/tar')
-        response['Content-Disposition'] = 'attachment; filename={}'.format(os.path.basename(tarf.encode('utf-8')))
+        outfilename = 'all_courses_as_{}_{}.tar'.format(
+            plugin_class.filename_extension,
+            datetime.datetime.now().strftime('%Y-%m-%d'))
+        response = StreamingHttpResponse(
+            core.export_courses_multiple(request.user, plugin_class, course_keys, outfilename, stream=True),
+            content_type='application/tar'
+        )
+        response['Content-Disposition'] = 'attachment; filename={}'.format(outfilename)
         return response

--- a/openedx_export_plugins/views.py
+++ b/openedx_export_plugins/views.py
@@ -22,7 +22,7 @@ from opaque_keys.edx.keys import CourseKey
 from openedx.core.lib.api import plugins
 from util.views import ensure_valid_course_key
 
-from . import core
+from . import constants, core
 from .plugins import CourseExporterPluginManager
 
 
@@ -67,8 +67,7 @@ def plugin_export_handler(request, plugin_name, course_key_string=None):
         # return a tarball of all export files in the response
         outfilename = constants.EXPORT_FILENAME_FORMAT_MULTIPLE.format(
             plugin_class.filename_extension,
-            datetime.datetime.now().strftime('%Y-%m-%d'),
-            ''
+            datetime.datetime.now().strftime('%Y-%m-%d')
         )
         response = StreamingHttpResponse(
             core.export_courses_multiple(request.user, plugin_class, course_keys, outfilename, stream=True),


### PR DESCRIPTION
We need to support  management command or Celery task-triggered export.  This PR refactors much of the existing export function into a new core module and support returning multiple course exports to stream Tar data over StreamingHTTPResponse or to directly output a gzipped tar file.